### PR TITLE
HelloWorldをlocalTimeの取得に変更

### DIFF
--- a/src/main/java/com/koki/helloworld/HelloworldApplication.java
+++ b/src/main/java/com/koki/helloworld/HelloworldApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class HelloworldApplication {
 
 	public static void main(String[] args) {
+
 		SpringApplication.run(HelloworldApplication.class, args);
 	}
 

--- a/src/main/java/com/koki/helloworld/HelloworldApplication.java
+++ b/src/main/java/com/koki/helloworld/HelloworldApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class HelloworldApplication {
 
     public static void main(String[] args) {
+        
         SpringApplication.run(HelloworldApplication.class, args);
     }
 

--- a/src/main/java/com/koki/helloworld/HelloworldApplication.java
+++ b/src/main/java/com/koki/helloworld/HelloworldApplication.java
@@ -6,9 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class HelloworldApplication {
 
-	public static void main(String[] args) {
-
-		SpringApplication.run(HelloworldApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(HelloworldApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/koki/helloworld/HelloworldController.java
+++ b/src/main/java/com/koki/helloworld/HelloworldController.java
@@ -15,8 +15,8 @@ public class HelloworldController {
     public String localTime() {
         LocalDateTime localTime = LocalDateTime.now();
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
-        String formatted = dateFormat.format(localTime);
-        return "Hello current time " + formatted;
+        String formattedLocalTime = dateFormat.format(localTime);
+        return "Hello current time " + formattedLocalTime;
 
     }
 

--- a/src/main/java/com/koki/helloworld/HelloworldController.java
+++ b/src/main/java/com/koki/helloworld/HelloworldController.java
@@ -3,13 +3,21 @@ package com.koki.helloworld;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+
 @RestController
 
 public class HelloworldController {
 
-        @GetMapping("/hello")
-        public String hello () {
-        return "Hello World";
+    @GetMapping("/localTime")
+    public String localTime() {
+        LocalDateTime localTime = LocalDateTime.now();
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+        String formatted = dateFormat.format(localTime);
+        return "Hello current time " + formatted;
+
     }
 
 }


### PR DESCRIPTION
### 変更内容

- helloworldと表示されるようにしていた部分をlocalTimeを取得し表示させるように変更し、ミリ秒は表示をフォーマットで切り捨てました。

- mainブランチでpushした際フォーマットしていなかったのでフォーマットしました。 
   現在はIntellJの設定を変更し自動フォーマットにしてます。

### 表示確認

![localhost-8080-localTime](https://github.com/kokiyoda/Spring-helloworld/assets/134734832/e8bbe3f6-3966-4eb6-8777-8ee5a1f8b404)
